### PR TITLE
Fixed `isButtonPressed`

### DIFF
--- a/src/sfml/window/mouse.zig
+++ b/src/sfml/window/mouse.zig
@@ -9,7 +9,7 @@ pub const Wheel = enum(c_uint) { Vertical, Horizontal };
 
 /// Returns true if the specified mouse button is pressed
 pub fn isButtonPressed(button: Button) bool {
-    return sf.c.sfMouse_isButtonPressed(@intToEnum(sf.c.sfMouseButton, @enumToInt(button))) == 1;
+    return sf.c.sfMouse_isButtonPressed(@enumToInt(button)) == 1;
 }
 
 /// Gets the position of the mouse cursor relative to the window passed or desktop


### PR DESCRIPTION
Fixed this error:
```
mouse.zig:12:56: error: expected enum, found type 'c_uint' 
    return sf.c.sfMouse_isButtonPressed(@intToEnum(sf.c.sfMouseButton, @enumToInt(button))) == 1;
```
By the way, enums in C are numbered the same way as in Zig.