### PR TITLE
Fix `isNum()` function and change `readme.md` example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ This is a small example of how you use this sfml wrapper:
 
 const sf = struct {
     usingnamespace @import("sfml");
-    usingnamespace sf.graphics;
+    usingnamespace @import("sfml").graphics;
 };
 
 pub fn main() !void {

--- a/readme.md
+++ b/readme.md
@@ -35,8 +35,9 @@ This is a small example of how you use this sfml wrapper:
 //! for instance, in this page: https://www.sfml-dev.org/tutorials/2.6/start-vc.php
 
 const sf = struct {
-    usingnamespace @import("sfml");
-    usingnamespace @import("sfml").graphics;
+    const sfml = @import("sfml");
+    usingnamespace sfml;
+    usingnamespace sfml.graphics;
 };
 
 pub fn main() !void {

--- a/src/system/vector.zig
+++ b/src/system/vector.zig
@@ -5,7 +5,7 @@ const sf = @import("../root.zig");
 
 fn isNum(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .Int, .Float, .ComptimeFloat, .ComptimeInt => true,
+        .int, .float, .comptime_float, .comptime_int => true,
         else => false,
     };
 }


### PR DESCRIPTION
Zig recently updated `std.builtin.Type` to have fields that are snake_case instead of camelCase, so I updated those fields in this library's `vector.zig` to make it work with the latest version of Zig.

Also, the importing in the `readme.md` example resulted in a "recursive import" error, so I fixed it by creating a variable called `sfml` inside the `sf` struct.

Now, the library is able to successfully compile and run as intended on my machine with Zig 0.14.0.